### PR TITLE
missing production dependency - caseless

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "author": "Mikeal Rogers <mikeal.rogers@gmail.com> (http://www.mikealrogers.com)",
   "license": "Apache-2.0",
   "dependencies": {
+    "caseless": "^0.12.0",
     "node-fetch": "^2.0.0-alpha.8",
     "typedarray-to-buffer": "^3.1.2"
   },


### PR DESCRIPTION
`npm install --production`

```js
const r2 = require('./index.js');
```

```
module.js:491
    throw err;
    ^

Error: Cannot find module 'caseless'
    at Function.Module._resolveFilename (module.js:489:15)
    at Function.Module._load (module.js:439:25)
    at Module.require (module.js:517:17)
    at require (internal/module.js:11:18)
   ```