### PR TITLE
Add travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,10 @@ os:
   - linux
   - osx
 node_js:
-  - '6'
-  - '7'
+# comment node 6 and 7 for now because tests are using 
+# require('util').promisify which is not available in node 6, 7
+#  - '6'
+#  - '7'
   - '8'
 before_install:
   - npm config set progress false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: node_js
+os:
+  - linux
+  - osx
+node_js:
+  - '6'
+  - '7'
+  - '8'
+before_install:
+  - npm config set progress false
+  - npm config set spin false
+script:
+  - npm test


### PR DESCRIPTION
Currently test files are using `require('util').promisify` so i will have to disable node 6 and 7 for now.

We can update tests and use something else to promisify (or not) and enable them later.