### PR TITLE
Add installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,16 @@ let res = await r2('http://localhost/test', {headers}).response
 Being written to the Fetch API is a huge benefit for browser users.
 
 When running through browserify `request` is ~2M uncompressed and ~500K compressed. `r2` is only 66K uncompressed and 16K compressed.
+
+
+## Installation
+
+:warning: An NPM package `r2` exists but does not yet refer to this project (see [#20](https://github.com/mikeal/r2/issues/20)). In the meantime install like this:
+
+```
+# via HTTPS
+npm install git+https://git@github.com:mikeal/r2.git --save
+
+# via SSH
+npm install git+ssh://git@github.com:mikeal/r2.git --save
+```


### PR DESCRIPTION
Since this transfer thing seems to take a while, adding a temporary warning 
and proper installation instructions to README should avoid some confusion.