### PR TITLE
improve webpack support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,9 @@
 /* globals fetch, Headers */
 /* istanbul ignore next */
 if (!process.browser) {
-  global.fetch = require('node-fetch')
-  global.Headers = global.fetch.Headers
+  const fetchModule = require('node-fetch')
+  global.fetch = fetchModule.default
+  global.Headers = fetchModule.Headers
 }
 
 const caseless = require('caseless')


### PR DESCRIPTION
If use webpack, `require('node-fetch')` is not imported by default. Then the `fetch` is a undefined, not a function.

@ilanc suggested using `require('node-fetch').default`.

https://github.com/webpack/webpack/issues/4742
https://github.com/bitinn/node-fetch/issues/450#issuecomment-387045223